### PR TITLE
hidden input name= id= tweak

### DIFF
--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -11,7 +11,7 @@
  * the fly. It supports keybord navigation (UP + DOWN + RETURN), as well
  * as multiple AutoSuggest fields on the same page.
  *
- * Inspied by the Autocomplete plugin by: Jšrn Zaefferer
+ * Inspied by the Autocomplete plugin by: Jï¿½rn Zaefferer
  * and the Facelist plugin by: Ian Tearle (iantearle.com)
  *
  * This AutoSuggest jQuery plug-in is dual licensed under the MIT and GPL licenses:
@@ -23,6 +23,8 @@
 	$.fn.autoSuggest = function(data, options) {
 		var defaults = { 
 			asHtmlID: false,
+			asHiddenInputName: false,
+			asHiddenInputID: false,
 			startText: "Enter Name Here",
 			emptyText: "No Results Found",
 			preFill: {},
@@ -81,7 +83,9 @@
 				var org_li = $("#as-original-"+x);				
 				var results_holder = $('<div class="as-results" id="as-results-'+x+'"></div>').hide();
 				var results_ul =  $('<ul class="as-list"></ul>');
-				var values_input = $('<input type="hidden" class="as-values" name="as_values_'+x+'" id="as-values-'+x+'" />');
+				if ( opts.asHiddenInputID != false ) { var asHiddenInputID = opts.asHiddenInputID; } else { var asHiddenInputID = 'as-values-'+x;}
+				if ( opts.asHiddenInputName != false ) { var asHiddenInputName = opts.HiddenInputName; } else { var asHiddenInputName = 'as_values_'+x;}
+				var values_input = $('<input type="hidden" class="as-values" name="'+asHiddenInputName+'" id="'+asHiddenInputID+'" />');
 				var prefill_value = "";
 				if(typeof opts.preFill == "string"){
 					var vals = opts.preFill.split(",");					

--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -84,7 +84,7 @@
 				var results_holder = $('<div class="as-results" id="as-results-'+x+'"></div>').hide();
 				var results_ul =  $('<ul class="as-list"></ul>');
 				if ( opts.asHiddenInputID != false ) { var asHiddenInputID = opts.asHiddenInputID; } else { var asHiddenInputID = 'as-values-'+x;}
-				if ( opts.asHiddenInputName != false ) { var asHiddenInputName = opts.HiddenInputName; } else { var asHiddenInputName = 'as_values_'+x;}
+				if ( opts.asHiddenInputName != false ) { var asHiddenInputName = opts.asHiddenInputName; } else { var asHiddenInputName = 'as_values_'+x;}
 				var values_input = $('<input type="hidden" class="as-values" name="'+asHiddenInputName+'" id="'+asHiddenInputID+'" />');
 				var prefill_value = "";
 				if(typeof opts.preFill == "string"){


### PR DESCRIPTION
Added support for overriding the name= and id= attribute of the hidden input element.

Added config options

asHiddenInputName
asHiddenInputID

setting them to...

asHiddenInputName: 'data[Part][tags]',
asHiddenInputID: 'PartTags',

...will result in...

<input type="hidden" class="as-values" name="data[Part][tags]" id="PartTags" value="">

omitting these options will result in normal behavior

btw. great work on the plugin!!!!!!!
